### PR TITLE
Icon buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Corrected the behavior of the icon buttons in the main menu.
+- Increased the brightness of the icon buttons in the main menu.
+
 ## Abuse 1.0.0 (2025-03-02)
 
 - **FPS Unlocked**: The game is no longer locked to 15 FPS. Frame rate is now interpolated to match your screen refresh rate.

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -108,7 +108,11 @@ void ico_button::draw(int active, image *screen)
     if (active != act && activate_id != -1 && active)
         wm->Push(new Event(activate_id, NULL));
 
-    screen->PutImage(cache.img((up && !active) ? u : (up && active) ? ua : (!up && !active) ? d : da), ivec2(x1, y1));
+    screen->PutImage(cache.img((up && !active)    ? up_inactive
+                               : (up && active)   ? up_active
+                               : (!up && !active) ? down_inactive
+                                                  : down_active),
+                     ivec2(x1, y1));
 
     if (act != active && active && activate_id != -1)
         wm->Push(new Event(activate_id, NULL));
@@ -147,12 +151,12 @@ void ico_button::area(int &x1, int &y1, int &x2, int &y2)
 {
     x1 = m_pos.x;
     y1 = m_pos.y;
-    x2 = m_pos.x + cache.img(u)->Size().x - 1;
-    y2 = m_pos.y + cache.img(u)->Size().y - 1;
+    x2 = m_pos.x + cache.img(up_inactive)->Size().x - 1;
+    y2 = m_pos.y + cache.img(up_inactive)->Size().y - 1;
 }
 
-ico_button::ico_button(int X, int Y, int ID, int Up, int down, int upa, int downa, ifield *Next, int act_id,
-                       char const *help_key)
+ico_button::ico_button(int x, int y, int id, int up_inactive, int down_inactive, int up_active, int down_active,
+                       ifield *next, int activate_id, char const *help_key)
 {
     if (help_key)
     {
@@ -163,14 +167,14 @@ ico_button::ico_button(int X, int Y, int ID, int Up, int down, int upa, int down
         key[0] = 0;
 
     up = 1;
-    m_pos = ivec2(X, Y);
-    id = ID;
-    u = Up;
-    d = down;
-    ua = upa;
-    da = downa;
-    next = Next;
-    activate_id = act_id;
+    m_pos = ivec2(x, y);
+    this->id = id;
+    this->up_inactive = up_inactive;
+    this->down_inactive = down_inactive;
+    this->up_active = up_active;
+    this->down_active = down_active;
+    this->next = next;
+    this->activate_id = activate_id;
     act = 0;
 }
 

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -120,7 +120,7 @@ void ico_button::draw(int active, image *screen)
 
     if (active && key[0])
     {
-        int g = 80;
+        int g = 127;
         screen->Bar(ivec2(0, 0), ivec2(144, 20), 0);
         wm->font()->PutString(screen, ivec2(3), symbol_str(key), color_table->Lookup(g >> 3, g >> 3, g >> 3));
     }

--- a/src/gui.h
+++ b/src/gui.h
@@ -14,13 +14,13 @@
 
 class ico_button : public ifield
 {
-    int up, act, u, d, ua, da; // up, down, up active, down active
+    int up, act, up_inactive, down_inactive, up_active, down_active;
     int activate_id; // sent when if not -1 when object receives a draw actove
     char key[16];
 
   public:
-    ico_button(int X, int Y, int ID, int Up, int down, int upa, int downa, ifield *Next, int act_id = -1,
-               char const *help_key = NULL);
+    ico_button(int x, int y, int id, int up_inactive, int down_inactive, int up_active, int down_active, ifield *next,
+               int activate_id = -1, char const *help_key = NULL);
 
     virtual void area(int &x1, int &y1, int &x2, int &y2);
     virtual void draw_first(image *screen)

--- a/src/gui.h
+++ b/src/gui.h
@@ -14,7 +14,7 @@
 
 class ico_button : public ifield
 {
-    int up, act, up_inactive, down_inactive, up_active, down_active;
+    int up, enabled, up_inactive, down_inactive, up_active, down_active;
     int activate_id; // sent when if not -1 when object receives a draw actove
     char key[16];
 

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -367,7 +367,7 @@ static ico_button *load_icon(int num, int id, int x, int y, int &h, ifield *next
 
     h = cache.img(a)->Size().y;
 
-    return new ico_button(x, y, id, b, b, a, c, next, -1, key);
+    return new ico_button(x, y, id, b, b, c, a, next, -1, key);
 }
 
 ico_button *make_default_buttons(int x, int &y, ico_button *append_list)


### PR DESCRIPTION
Fixes icon button states and uses the brighter sprites by default instead of only on hover. Slightly increases brightness of help text in the upper left.

![Screenshot From 2025-03-07 00-23-40](https://github.com/user-attachments/assets/ac66c611-4d89-4096-9b93-b2bfa34b3607)

Fixes #3 
